### PR TITLE
perf(hordeweb): migrate feed and library caches to PSR-16, add diag route

### DIFF
--- a/app/lib/HordeWeb/Utils.php
+++ b/app/lib/HordeWeb/Utils.php
@@ -332,11 +332,17 @@ class HordeWeb_Utils
     }
 
     /**
-     * @TODO: Remove core - configure via config values from config/
+     * Return the site-configured PSR-16 cache backend.
+     *
+     * Resolved via {@see \Horde\Core\Factory\SimpleCacheFactory} — the
+     * concrete storage (HashTable/Redis on production, whatever the
+     * site configured) is opaque to callers. Keys must be self-namespaced
+     * by the caller because the injected cache is a *site-shared*
+     * keyspace with no per-app prefix applied.
      */
-    static public function getCache()
+    static public function getCache(): \Psr\SimpleCache\CacheInterface
     {
-        return $GLOBALS['injector']->getInstance('Horde_Cache');
+        return $GLOBALS['injector']->getInstance(\Psr\SimpleCache\CacheInterface::class);
     }
 
     /**

--- a/app/lib/HordeWeb/Utils/Libraries.php
+++ b/app/lib/HordeWeb/Utils/Libraries.php
@@ -14,11 +14,30 @@
  * @license  http://www.fsf.org/copyleft/lgpl.html LGPL
  * @link     http://www.horde.org
  */
+
+use Psr\SimpleCache\CacheInterface;
+
 class HordeWeb_Utils_Libraries
 {
-    private Horde_Cache $_cache;
+    /**
+     * TTL (seconds) for the two library-metadata cache entries.
+     * The corpus is a directory of static JSON files — rebuild is cheap
+     * — but the cached form pre-flattens/sort/filters the entire set,
+     * so paying for it once per day per era is worth it.
+     */
+    private const CACHE_TTL = 86400;
 
-    public function __construct(Horde_Cache $cache)
+    /**
+     * Namespace for this class's cache keys. Prefixed with 'hordeweb.'
+     * because the injected PSR-16 backend is a *site-shared* keyspace
+     * (Redis on typical Horde installs); the app has to prefix its own
+     * keys.
+     */
+    private const CACHE_NS = 'hordeweb.libraries.';
+
+    private CacheInterface $_cache;
+
+    public function __construct(CacheInterface $cache)
     {
         $this->_cache = $cache;
     }
@@ -31,9 +50,13 @@ class HordeWeb_Utils_Libraries
      */
     public function listLibraries(string $era = 'h6'): array
     {
-        $cacheKey = __CLASS__ . '::list::' . $era;
-        if ($list = $this->_cache->get($cacheKey, 86400)) {
-            return unserialize($list);
+        $cacheKey = self::CACHE_NS . 'list.' . $era;
+        $cached = $this->_cache->get($cacheKey);
+        if ($cached !== null) {
+            $unserialized = @unserialize($cached);
+            if (is_array($unserialized)) {
+                return $unserialized;
+            }
         }
         $components = $this->_getComponents($era);
         $list = array();
@@ -42,7 +65,7 @@ class HordeWeb_Utils_Libraries
         }
         $list = array_filter($list, array($this, '_hideApplications'));
         sort($list);
-        $this->_cache->set($cacheKey, serialize($list));
+        $this->_cache->set($cacheKey, serialize($list), self::CACHE_TTL);
         return $list;
     }
 
@@ -59,9 +82,13 @@ class HordeWeb_Utils_Libraries
      */
     public function listDescriptions(string $era = 'h6'): array
     {
-        $cacheKey = __CLASS__ . '::descriptions::' . $era;
-        if ($descriptions = $this->_cache->get($cacheKey, 86400)) {
-            return unserialize($descriptions);
+        $cacheKey = self::CACHE_NS . 'descriptions.' . $era;
+        $cached = $this->_cache->get($cacheKey);
+        if ($cached !== null) {
+            $unserialized = @unserialize($cached);
+            if (is_array($unserialized)) {
+                return $unserialized;
+            }
         }
         $components = $this->_getComponents($era);
         $descriptions = array();
@@ -69,7 +96,7 @@ class HordeWeb_Utils_Libraries
             $descriptions[$component->name] = $component->description;
         }
         ksort($descriptions);
-        $this->_cache->set($cacheKey, serialize($descriptions));
+        $this->_cache->set($cacheKey, serialize($descriptions), self::CACHE_TTL);
         return $descriptions;
     }
 

--- a/app/lib/base.php
+++ b/app/lib/base.php
@@ -6,22 +6,52 @@
  */
 
 require_once dirname(__FILE__) . '/../../config/conf.php';
+
+// config/conf.php declares $host_base, $fs_base, $site_name, $feed_url,
+// $planet_feed_url and $feed_timeout at file scope. When base.php is
+// loaded from a function (e.g. the LegacyBootstrap middleware under
+// rampage) those become function locals; the legacy code and views
+// throughout hordeweb read them off $GLOBALS. Promote them here so
+// both entry points expose the same globals.
+foreach (['host_base', 'fs_base', 'site_name', 'feed_url', 'planet_feed_url', 'feed_timeout', 'diag_token'] as $__hwvar) {
+    if (isset($$__hwvar)) {
+        $GLOBALS[$__hwvar] = $$__hwvar;
+    }
+}
+unset($__hwvar);
+
 require_once HORDE_BASE . '/lib/core.php';
 $session_control = 'none';
 $nocompress = true;
 Horde_Registry::appInit('horde', array('authentication' => 'none', 'nocompress' => $nocompress, 'session_control' => $session_control));
-$GLOBALS['injector']->getInstance('Horde_Autoloader')->addClassPathMapper(new Horde_Autoloader_ClassPathMapper_Default($fs_base . '/app/lib/'));
+
+// The injector's Horde_Autoloader binding is not always the SPL-registered
+// instance under rampage: composer's autoloader chain preloads
+// Horde_Autoloader_Default.php, which self-registers a fresh instance
+// on SPL before the injector binding is made. Locate the actual SPL
+// instance and add our class-path mappers there.
+$autoloader = null;
+foreach (spl_autoload_functions() ?: [] as $fn) {
+    if (is_array($fn) && is_object($fn[0]) && $fn[0] instanceof Horde_Autoloader) {
+        $autoloader = $fn[0];
+        break;
+    }
+}
+if ($autoloader === null) {
+    $autoloader = $GLOBALS['injector']->getInstance('Horde_Autoloader');
+}
+$autoloader->addClassPathMapper(new Horde_Autoloader_ClassPathMapper_Default($fs_base . '/app/lib/'));
 $applicationMapper = new Horde_Autoloader_ClassPathMapper_Application($fs_base .  '/app');
 $applicationMapper->addMapping('Controller', 'controllers');
 $applicationMapper->addMapping('SettingsExporter', 'settings');
-$__autoloader->addClassPathMapper($applicationMapper);
+$autoloader->addClassPathMapper($applicationMapper);
 
 $myMapper = new Horde_Autoloader_ClassPathMapper_Prefix('/^HordeWeb_/', $fs_base . '/app/lib/HordeWeb');
-$__autoloader->addClassPathMapper($myMapper);
+$autoloader->addClassPathMapper($myMapper);
 
 // PSR-4 autoloader for modern controllers (HordeWeb\Controller\*)
 $psr4Mapper = new Horde_Autoloader_ClassPathMapper_Prefix('/^HordeWeb\\\\/', $fs_base . '/srv/HordeWeb');
-$__autoloader->addClassPathMapper($psr4Mapper);
+$autoloader->addClassPathMapper($psr4Mapper);
 
 /* Binders */
 $GLOBALS['injector']->bindFactory('HordeWeb_View', 'HordeWeb_Factory_View', 'create');

--- a/bin/hordeweb-fetch-feed
+++ b/bin/hordeweb-fetch-feed
@@ -1,269 +1,117 @@
 #!/usr/bin/env php
 <?php
 /**
- * Test feed retrieval and caching
+ * Warm the hordeweb feed cache.
  *
- * This script tests the RSS feed fetching and caching mechanism used on the
- * home page. It performs the same initialization as the web application,
- * fetches both feeds, caches them, and then retrieves from cache.
+ * Fetches the two feeds used by the home page and stores them in the
+ * shared PSR-16 cache under the same keys/TTL the request path uses,
+ * so a warm entry is always available when a visitor lands.
  *
- * Usage:
- *   ./bin/test-feeds.php
+ * Safety properties this script promises:
+ *   1. Do NOT delete existing cache entries before fetching. A previous
+ *      good entry survives a failed refresh.
+ *   2. Write only on successful fetch. Failure leaves the previous
+ *      good copy in place. (The web path stamps its own short-lived
+ *      negative sentinel; cron does not, so cron never suppresses a
+ *      request-path retry.)
+ *   3. Use the same PSR-16 CacheInterface the controllers use — via
+ *      Horde\Core\Factory\SimpleCacheFactory — so cron warmups and
+ *      request-path reads share exactly one keyspace.
  *
- * Copyright 2026 Horde LLC (http://www.horde.org)
+ * Intended for cron. Exit codes:
+ *   0 — all feeds refreshed (or already fresh, we don't care).
+ *   1 — one or more feeds failed to fetch. Previous cache entries
+ *       are preserved; this exit code is only a signal to cron/mon.
+ *
+ * Copyright 2011-2026 Horde LLC (http://www.horde.org)
  *
  * @license  http://opensource.org/licenses/bsd-license.php BSD
  */
 
 declare(strict_types=1);
 
-// Ensure script is only run from CLI
 if (PHP_SAPI !== 'cli') {
     http_response_code(403);
     exit;
 }
 
-// Enable all error reporting including deprecations and notices
-error_reporting(E_ALL);
-ini_set('display_errors', '1');
-ini_set('display_startup_errors', '1');
-
-// Determine project root
 $projectRoot = dirname(__DIR__);
 
-// Load composer autoloader if not already present
 if (!class_exists('Horde_Autoloader')) {
-    $autoloadPaths = [
+    foreach ([
         $projectRoot . '/vendor/autoload.php',
-        $projectRoot . '/../../autoload.php', // If installed as dependency
-    ];
-
-    foreach ($autoloadPaths as $autoloadPath) {
+        $projectRoot . '/../../autoload.php',
+    ] as $autoloadPath) {
         if (file_exists($autoloadPath)) {
             require_once $autoloadPath;
-            echo "Loaded autoloader from: $autoloadPath\n";
             break;
         }
     }
 }
 
-// Bootstrap the application (same as web does)
 require_once $projectRoot . '/app/lib/base.php';
 
-// Override error handler to ensure all errors are visible
-// appInit may have installed a custom error handler that suppresses some errors
-set_error_handler(function($errno, $errstr, $errfile, $errline) {
-    $errorTypes = [
-        E_ERROR => 'ERROR',
-        E_WARNING => 'WARNING',
-        E_PARSE => 'PARSE',
-        E_NOTICE => 'NOTICE',
-        E_CORE_ERROR => 'CORE_ERROR',
-        E_CORE_WARNING => 'CORE_WARNING',
-        E_COMPILE_ERROR => 'COMPILE_ERROR',
-        E_COMPILE_WARNING => 'COMPILE_WARNING',
-        E_USER_ERROR => 'USER_ERROR',
-        E_USER_WARNING => 'USER_WARNING',
-        E_USER_NOTICE => 'USER_NOTICE',
-        E_RECOVERABLE_ERROR => 'RECOVERABLE_ERROR',
-        E_DEPRECATED => 'DEPRECATED',
-        E_USER_DEPRECATED => 'USER_DEPRECATED',
-    ];
+use Psr\SimpleCache\CacheInterface;
 
-    $type = $errorTypes[$errno] ?? "UNKNOWN($errno)";
-    echo "\n[PHP $type] $errstr in $errfile on line $errline\n";
+/** Match Home::SUCCESS_TTL — 10 minutes. */
+const HORDEWEB_FEED_TTL = 600;
 
-    // Don't execute PHP internal error handler
-    return true;
-});
+/** Same key namespace the Home controller reads from. */
+const HORDEWEB_FEED_KEY_PLANET    = 'hordeweb.feed.planet.v2';
+const HORDEWEB_FEED_KEY_HORDEFEED = 'hordeweb.feed.horde.v2';
 
-// Get timeout from config with fallback
-$feedTimeout = $GLOBALS['feed_timeout'] ?? 30;
-echo "Feed timeout: {$feedTimeout} seconds\n\n";
-
-echo "=== Feed Retrieval and Caching Test ===\n\n";
-
-// Get cache instance
-$cache = $GLOBALS['injector']->getInstance('Horde_Cache');
-echo "Cache instance: " . get_class($cache) . "\n\n";
-
-// Cache version (same as Home controller)
-$cacheVersion = 'v2';
-
-// Create HTTP client with custom timeout (same as Home controller)
 $feedTimeout = $GLOBALS['feed_timeout'] ?? 5;
 $httpClient = new Horde_Http_Client(['request.timeout' => $feedTimeout]);
-echo "Using HTTP client timeout: {$feedTimeout} seconds\n\n";
 
-// Test 1: Planet Horde Feed
-echo "--- Test 1: Planet Horde Feed ---\n";
-$planetFeedUrl = $GLOBALS['planet_feed_url'] ?? 'https://www.ralf-lang.de/tag/horde/feed/';
-echo "URL: $planetFeedUrl\n";
+$cache = $GLOBALS['injector']->getInstance(CacheInterface::class);
+echo "Cache backend: " . get_class($cache) . "\n";
+echo "Feed timeout:  {$feedTimeout}s\n";
+echo "TTL:           " . HORDEWEB_FEED_TTL . "s\n\n";
 
-$planetKey = 'planet_' . $cacheVersion;
-echo "Cache key: $planetKey\n";
+$feeds = [
+    'planet' => [
+        'key' => HORDEWEB_FEED_KEY_PLANET,
+        'url' => $GLOBALS['planet_feed_url'] ?? 'https://www.ralf-lang.de/tag/horde/feed/',
+    ],
+    'horde' => [
+        'key' => HORDEWEB_FEED_KEY_HORDEFEED,
+        'url' => $GLOBALS['feed_url'],
+    ],
+];
 
-// Check for existing cache first
-echo "Checking for existing cache...\n";
-$hadExistingCache = false;
-if ($existingCache = $cache->get($planetKey, 600)) {
-    $hadExistingCache = true;
-    echo "✓ Found existing cache\n";
-    $unserialized = @unserialize($existingCache);
-    if ($unserialized && is_iterable($unserialized)) {
-        echo "Existing cached feed title: " . ($unserialized->title ?? 'N/A') . "\n";
-        $itemCount = 0;
-        foreach ($unserialized as $entry) {
-            $itemCount++;
-            if ($itemCount <= 3) {
-                echo "  - " . ($entry->title ?? 'Untitled') . "\n";
-            }
-        }
-        echo "Total cached items: $itemCount\n";
-    } else {
-        echo "⚠ Existing cache corrupted\n";
+$exit = 0;
+
+foreach ($feeds as $label => $spec) {
+    echo "--- {$label} ---\n";
+    echo "URL: {$spec['url']}\n";
+    echo "Key: {$spec['key']}\n";
+
+    try {
+        $feed = @Horde_Feed::readUri($spec['url'], $httpClient);
+    } catch (Throwable $e) {
+        echo "FAILED: " . get_class($e) . ": " . $e->getMessage() . "\n";
+        echo "Previous cache entry (if any) left intact.\n\n";
+        $exit = 1;
+        continue;
     }
-} else {
-    echo "✗ No existing cache found\n";
+
+    if ($feed === null || $feed === false) {
+        echo "FAILED: fetch returned null/false (probably a parse error suppressed by @).\n";
+        echo "Previous cache entry (if any) left intact.\n\n";
+        $exit = 1;
+        continue;
+    }
+
+    $items = 0;
+    foreach ($feed as $_) {
+        $items++;
+    }
+
+    $cache->set($spec['key'], serialize($feed), HORDEWEB_FEED_TTL);
+    // Clear any negative sentinel a prior in-request failure may have set.
+    $cache->delete($spec['key'] . '.failed');
+
+    echo "OK: {$items} items cached\n\n";
 }
 
-// Clear cache for testing
-$cache->expire($planetKey);
-echo "Cleared cache for fresh test\n";
-
-// Fetch feed
-echo "Fetching feed...\n";
-try {
-    $planet = Horde_Feed::readUri($planetFeedUrl, $httpClient);
-    echo "✓ Successfully fetched feed\n";
-    echo "Feed title: " . ($planet->title ?? 'N/A') . "\n";
-
-    // Count items
-    $itemCount = 0;
-    foreach ($planet as $entry) {
-        $itemCount++;
-        if ($itemCount <= 3) {
-            echo "  - " . ($entry->title ?? 'Untitled') . "\n";
-        }
-    }
-    echo "Total items: $itemCount\n";
-
-    // Cache it
-    echo "Caching feed...\n";
-    $cache->set($planetKey, serialize($planet));
-    echo "✓ Feed cached\n";
-
-    // Retrieve from cache immediately after write
-    echo "Reading back from " . ($hadExistingCache ? "newly written" : "just written") . " cache...\n";
-    if ($cached = $cache->get($planetKey, 600)) {
-        $unserialized = @unserialize($cached);
-        if ($unserialized && is_iterable($unserialized)) {
-            echo "✓ Successfully retrieved from cache\n";
-            echo "Cached feed title: " . ($unserialized->title ?? 'N/A') . "\n";
-            $cachedItemCount = 0;
-            foreach ($unserialized as $entry) {
-                $cachedItemCount++;
-                if ($cachedItemCount <= 3) {
-                    echo "  - " . ($entry->title ?? 'Untitled') . "\n";
-                }
-            }
-            echo "Total cached items: $cachedItemCount\n";
-        } else {
-            echo "✗ Cache data corrupted or invalid\n";
-        }
-    } else {
-        echo "✗ Cache miss\n";
-    }
-
-} catch (Throwable $e) {
-    echo "✗ ERROR: " . get_class($e) . "\n";
-    echo "Message: " . $e->getMessage() . "\n";
-    echo "File: " . $e->getFile() . ":" . $e->getLine() . "\n";
-}
-
-echo "\n--- Test 2: Horde News Feed ---\n";
-$feedUrl = $GLOBALS['feed_url'] ?? 'https://dev.horde.org/horde/jonah/delivery/rss.php?channel_id=1';
-echo "URL: $feedUrl\n";
-
-$hordefeedKey = 'hordefeed_' . $cacheVersion;
-echo "Cache key: $hordefeedKey\n";
-
-// Check for existing cache first
-echo "Checking for existing cache...\n";
-$hadExistingCache = false;
-if ($existingCache = $cache->get($hordefeedKey, 600)) {
-    $hadExistingCache = true;
-    echo "✓ Found existing cache\n";
-    $unserialized = @unserialize($existingCache);
-    if ($unserialized && is_iterable($unserialized)) {
-        echo "Existing cached feed title: " . ($unserialized->title ?? 'N/A') . "\n";
-        $itemCount = 0;
-        foreach ($unserialized as $entry) {
-            $itemCount++;
-            if ($itemCount <= 3) {
-                echo "  - " . ($entry->title ?? 'Untitled') . "\n";
-            }
-        }
-        echo "Total cached items: $itemCount\n";
-    } else {
-        echo "⚠ Existing cache corrupted\n";
-    }
-} else {
-    echo "✗ No existing cache found\n";
-}
-
-// Clear cache for testing
-$cache->expire($hordefeedKey);
-echo "Cleared cache for fresh test\n";
-
-// Fetch feed
-echo "Fetching feed...\n";
-try {
-    $hordefeed = Horde_Feed::readUri($feedUrl, $httpClient);
-    echo "✓ Successfully fetched feed\n";
-    echo "Feed title: " . ($hordefeed->title ?? 'N/A') . "\n";
-
-    // Count items
-    $itemCount = 0;
-    foreach ($hordefeed as $entry) {
-        $itemCount++;
-        if ($itemCount <= 3) {
-            echo "  - " . ($entry->title ?? 'Untitled') . "\n";
-        }
-    }
-    echo "Total items: $itemCount\n";
-
-    // Cache it
-    echo "Caching feed...\n";
-    $cache->set($hordefeedKey, serialize($hordefeed));
-    echo "✓ Feed cached\n";
-
-    // Retrieve from cache immediately after write
-    echo "Reading back from " . ($hadExistingCache ? "newly written" : "just written") . " cache...\n";
-    if ($cached = $cache->get($hordefeedKey, 600)) {
-        $unserialized = @unserialize($cached);
-        if ($unserialized && is_iterable($unserialized)) {
-            echo "✓ Successfully retrieved from cache\n";
-            echo "Cached feed title: " . ($unserialized->title ?? 'N/A') . "\n";
-            $cachedItemCount = 0;
-            foreach ($unserialized as $entry) {
-                $cachedItemCount++;
-                if ($cachedItemCount <= 3) {
-                    echo "  - " . ($entry->title ?? 'Untitled') . "\n";
-                }
-            }
-            echo "Total cached items: $cachedItemCount\n";
-        } else {
-            echo "✗ Cache data corrupted or invalid\n";
-        }
-    } else {
-        echo "✗ Cache miss\n";
-    }
-
-} catch (Throwable $e) {
-    echo "✗ ERROR: " . get_class($e) . "\n";
-    echo "Message: " . $e->getMessage() . "\n";
-    echo "File: " . $e->getFile() . ":" . $e->getLine() . "\n";
-}
-
-echo "\n=== Test Complete ===\n";
+exit($exit);

--- a/config/routes.php
+++ b/config/routes.php
@@ -9,286 +9,324 @@ use Horde\Hordeweb\Controller\Community;
 use Horde\Hordeweb\Controller\Licenses;
 use Horde\Hordeweb\Controller\Support;
 use Horde\Hordeweb\Controller\App;
+use Horde\Hordeweb\Controller\Diagnostics;
 use Horde\Hordeweb\Controller\Library;
 use Horde\Hordeweb\Controller\Development;
 use Horde\Hordeweb\Controller\Services;
 use Horde\Hordeweb\Controller\Download;
 use Horde\Hordeweb\Controller\Shop;
+use Horde\Hordeweb\Middleware\LegacyBootstrap;
+use Horde\Core\Middleware\HordeCore;
+use Horde\Core\Middleware\ErrorFilter;
+use Horde\Routes\GroupMapper;
 
-$_root = ltrim(dirname($_SERVER['PHP_SELF']), '/');
+/*
+ * All hordeweb routes share the same middleware stack:
+ *
+ *   HordeCore       — bootstraps the legacy Horde framework (registry,
+ *                     $GLOBALS['injector'], factories) that hordeweb's
+ *                     controllers reach into.
+ *   ErrorFilter     — renders exceptions as the Horde error page instead
+ *                     of leaking stack traces.
+ *   LegacyBootstrap — hordeweb-specific: require_once app/lib/base.php
+ *                     so PSR-0 mappers, $GLOBALS['fs_base']/$host_base and
+ *                     the bindFactory('HordeWeb_View', ...) call are in
+ *                     place before the controller runs.
+ *
+ * hordeweb is a fully public site; no AuthHordeSession/RedirectToLogin.
+ * Under horde/rampage.php this stack overrides the DefaultStack (which
+ * would demand authentication). Under hordeweb's own dispatch.php the
+ * stack is currently informational — dispatch.php runs the controller
+ * directly — but declaring it here keeps both entry points in sync and
+ * lets future work reuse the same middleware pipeline for standalone.
+ */
+$mapper->group(
+    ['stack' => [HordeCore::class, ErrorFilter::class, LegacyBootstrap::class]],
+    function (GroupMapper $mapper) {
+        /* Home controller routes */
+        $mapper->buildRoute('/')
+            ->withName('home')
+            ->withController(Home::class)
+            ->withAction('index')
+            ->add();
 
-/* Home controller routes */
-$mapper->buildRoute($_root . '/')
-    ->withName('home')
-    ->withController(Home::class)
-    ->withAction('index')
-    ->add();
+        $mapper->buildRoute('/contact/')
+            ->withName('contact')
+            ->withController(Home::class)
+            ->withAction('contact')
+            ->add();
 
-$mapper->buildRoute($_root . '/contact/')
-    ->withName('contact')
-    ->withController(Home::class)
-    ->withAction('contact')
-    ->add();
+        $mapper->buildRoute('/thanks')
+            ->withName('thanks')
+            ->withController(Home::class)
+            ->withAction('thanks')
+            ->add();
 
-$mapper->buildRoute($_root . '/thanks')
-    ->withName('thanks')
-    ->withController(Home::class)
-    ->withAction('thanks')
-    ->add();
+        $mapper->buildRoute('/logos')
+            ->withName('logos')
+            ->withController(Home::class)
+            ->withAction('logos')
+            ->add();
 
-$mapper->buildRoute($_root . '/logos')
-    ->withName('logos')
-    ->withController(Home::class)
-    ->withAction('logos')
-    ->add();
+        $mapper->buildRoute('/410')
+            ->withName('410')
+            ->withController(Home::class)
+            ->withAction('410')
+            ->add();
 
-$mapper->buildRoute($_root . '/410')
-    ->withName('410')
-    ->withController(Home::class)
-    ->withAction('410')
-    ->add();
+        $mapper->buildRoute('/mail')
+            ->withName('mail')
+            ->withController(Home::class)
+            ->withAction('mail')
+            ->add();
 
-$mapper->buildRoute($_root . '/mail')
-    ->withName('mail')
-    ->withController(Home::class)
-    ->withAction('mail')
-    ->add();
+        /* Community */
+        $mapper->buildRoute('/community/:action')
+            ->withName('community')
+            ->withController(Community::class)
+            ->defaults('action', 'index')
+            ->add();
 
-/* Community */
-$mapper->buildRoute($_root . '/community/:action')
-    ->withName('community')
-    ->withController(Community::class)
-    ->defaults('action', 'index')
-    ->add();
+        $mapper->buildRoute('/community/team')
+            ->withName('team')
+            ->withController(Community::class)
+            ->withAction('team')
+            ->add();
 
-$mapper->buildRoute($_root . '/community/team')
-    ->withName('team')
-    ->withController(Community::class)
-    ->withAction('team')
-    ->add();
+        $mapper->buildRoute('/community/localization')
+            ->withName('localization')
+            ->withController(Community::class)
+            ->withAction('localization')
+            ->add();
 
-$mapper->buildRoute($_root . '/community/localization')
-    ->withName('localization')
-    ->withController(Community::class)
-    ->withAction('localization')
-    ->add();
+        /* Licenses */
+        $mapper->buildRoute('/licenses/:action')
+            ->withName('licenses')
+            ->withController(Licenses::class)
+            ->defaults('action', 'index')
+            ->add();
 
-/* Licenses */
-$mapper->buildRoute($_root . '/licenses/:action')
-    ->withName('licenses')
-    ->withController(Licenses::class)
-    ->defaults('action', 'index')
-    ->add();
+        /* Support */
+        $mapper->buildRoute('/support')
+            ->withName('support')
+            ->withController(Support::class)
+            ->withAction('index')
+            ->add();
 
-/* Support */
-$mapper->buildRoute($_root . '/support')
-    ->withName('support')
-    ->withController(Support::class)
-    ->withAction('index')
-    ->add();
+        /* Apps - main index aliases to h6 */
+        $mapper->buildRoute('/apps')
+            ->withName('apps')
+            ->withController(App::class)
+            ->withAction('index')
+            ->add();
 
-/* Apps - main index aliases to h6 */
-$mapper->buildRoute($_root . '/apps')
-    ->withName('apps')
-    ->withController(App::class)
-    ->withAction('index')
-    ->add();
+        /* Apps - Horde 5 archive */
+        $mapper->buildRoute('/apps/h5')
+            ->withName('apps_h5')
+            ->withController(App::class)
+            ->withAction('h5')
+            ->add();
 
-/* Apps - Horde 5 archive */
-$mapper->buildRoute($_root . '/apps/h5')
-    ->withName('apps_h5')
-    ->withController(App::class)
-    ->withAction('h5')
-    ->add();
+        $mapper->buildRoute('/apps/h5/:app/docs/:file')
+            ->withName('app_h5_docs')
+            ->withController(App::class)
+            ->withAction('docs')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/h5/:app/docs/:file')
-    ->withName('app_h5_docs')
-    ->withController(App::class)
-    ->withAction('docs')
-    ->add();
+        $mapper->buildRoute('/apps/h5/:app')
+            ->withName('app_h5')
+            ->withController(App::class)
+            ->withAction('app')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/h5/:app')
-    ->withName('app_h5')
-    ->withController(App::class)
-    ->withAction('app')
-    ->add();
+        $mapper->buildRoute('/apps/h5/:app/:action')
+            ->withName('app_h5_action')
+            ->withController(App::class)
+            ->defaults('action', 'app')
+            ->withSecondaryRoute('/apps/h5/:app/screenshots')
+            ->withSecondaryRoute('/apps/h5/:app/screenshots_old')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/h5/:app/:action')
-    ->withName('app_h5_action')
-    ->withController(App::class)
-    ->defaults('action', 'app')
-    ->withSecondaryRoute($_root . '/apps/h5/:app/screenshots')
-    ->withSecondaryRoute($_root . '/apps/h5/:app/screenshots_old')
-    ->add();
+        /* Apps - Horde 6 */
+        $mapper->buildRoute('/apps/h6')
+            ->withName('apps_h6')
+            ->withController(App::class)
+            ->withAction('h6')
+            ->add();
 
-/* Apps - Horde 6 */
-$mapper->buildRoute($_root . '/apps/h6')
-    ->withName('apps_h6')
-    ->withController(App::class)
-    ->withAction('h6')
-    ->add();
+        $mapper->buildRoute('/apps/h6/:app/docs/:file')
+            ->withName('app_h6_docs')
+            ->withController(App::class)
+            ->withAction('docs')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/h6/:app/docs/:file')
-    ->withName('app_h6_docs')
-    ->withController(App::class)
-    ->withAction('docs')
-    ->add();
+        $mapper->buildRoute('/apps/h6/:app')
+            ->withName('app_h6')
+            ->withController(App::class)
+            ->withAction('app')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/h6/:app')
-    ->withName('app_h6')
-    ->withController(App::class)
-    ->withAction('app')
-    ->add();
+        $mapper->buildRoute('/apps/h6/:app/:action')
+            ->withName('app_h6_action')
+            ->withController(App::class)
+            ->defaults('action', 'app')
+            ->withSecondaryRoute('/apps/h6/:app/screenshots')
+            ->withSecondaryRoute('/apps/h6/:app/screenshots_old')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/h6/:app/:action')
-    ->withName('app_h6_action')
-    ->withController(App::class)
-    ->defaults('action', 'app')
-    ->withSecondaryRoute($_root . '/apps/h6/:app/screenshots')
-    ->withSecondaryRoute($_root . '/apps/h6/:app/screenshots_old')
-    ->add();
+        /* Apps - individual app routes (legacy, matches after h5/h6) */
+        $mapper->buildRoute('/apps/:app/docs/:file')
+            ->withName('app_docs')
+            ->withController(App::class)
+            ->withAction('docs')
+            ->add();
 
-/* Apps - individual app routes (legacy, matches after h5/h6) */
-$mapper->buildRoute($_root . '/apps/:app/docs/:file')
-    ->withName('app_docs')
-    ->withController(App::class)
-    ->withAction('docs')
-    ->add();
+        $mapper->buildRoute('/apps/:app')
+            ->withName('app')
+            ->withController(App::class)
+            ->withAction('app')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/:app')
-    ->withName('app')
-    ->withController(App::class)
-    ->withAction('app')
-    ->add();
+        $mapper->buildRoute('/apps/:app/:action')
+            ->withName('app_action')
+            ->withController(App::class)
+            ->defaults('action', 'app')
+            ->withSecondaryRoute('/apps/:app/screenshots')
+            ->withSecondaryRoute('/apps/:app/screenshots_old')
+            ->add();
 
-$mapper->buildRoute($_root . '/apps/:app/:action')
-    ->withName('app_action')
-    ->withController(App::class)
-    ->defaults('action', 'app')
-    ->withSecondaryRoute($_root . '/apps/:app/screenshots')
-    ->withSecondaryRoute($_root . '/apps/:app/screenshots_old')
-    ->add();
+        /* Libraries - main index aliases to h6 */
+        $mapper->buildRoute('/libraries')
+            ->withName('libraries')
+            ->withController(Library::class)
+            ->withAction('index')
+            ->add();
 
-/* Libraries - main index aliases to h6 */
-$mapper->buildRoute($_root . '/libraries')
-    ->withName('libraries')
-    ->withController(Library::class)
-    ->withAction('index')
-    ->add();
+        /* Libraries - Horde 5 archive */
+        $mapper->buildRoute('/libraries/h5')
+            ->withName('libraries_h5')
+            ->withController(Library::class)
+            ->withAction('h5')
+            ->add();
 
-/* Libraries - Horde 5 archive */
-$mapper->buildRoute($_root . '/libraries/h5')
-    ->withName('libraries_h5')
-    ->withController(Library::class)
-    ->withAction('h5')
-    ->add();
+        $mapper->buildRoute('/libraries/h5/:library/docs/:file')
+            ->withName('library_h5_docs')
+            ->withController(Library::class)
+            ->withAction('docs')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/h5/:library/docs/:file')
-    ->withName('library_h5_docs')
-    ->withController(Library::class)
-    ->withAction('docs')
-    ->add();
+        $mapper->buildRoute('/libraries/h5/:library')
+            ->withName('library_h5')
+            ->withController(Library::class)
+            ->withAction('library')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/h5/:library')
-    ->withName('library_h5')
-    ->withController(Library::class)
-    ->withAction('library')
-    ->add();
+        $mapper->buildRoute('/libraries/h5/:library/:action')
+            ->withName('library_h5_action')
+            ->withController(Library::class)
+            ->defaults('action', 'library')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/h5/:library/:action')
-    ->withName('library_h5_action')
-    ->withController(Library::class)
-    ->defaults('action', 'library')
-    ->add();
+        /* Libraries - Horde 6 */
+        $mapper->buildRoute('/libraries/h6')
+            ->withName('libraries_h6')
+            ->withController(Library::class)
+            ->withAction('h6')
+            ->add();
 
-/* Libraries - Horde 6 */
-$mapper->buildRoute($_root . '/libraries/h6')
-    ->withName('libraries_h6')
-    ->withController(Library::class)
-    ->withAction('h6')
-    ->add();
+        $mapper->buildRoute('/libraries/h6/:library/docs/:file')
+            ->withName('library_h6_docs')
+            ->withController(Library::class)
+            ->withAction('docs')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/h6/:library/docs/:file')
-    ->withName('library_h6_docs')
-    ->withController(Library::class)
-    ->withAction('docs')
-    ->add();
+        $mapper->buildRoute('/libraries/h6/:library')
+            ->withName('library_h6')
+            ->withController(Library::class)
+            ->withAction('library')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/h6/:library')
-    ->withName('library_h6')
-    ->withController(Library::class)
-    ->withAction('library')
-    ->add();
+        $mapper->buildRoute('/libraries/h6/:library/:action')
+            ->withName('library_h6_action')
+            ->withController(Library::class)
+            ->defaults('action', 'library')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/h6/:library/:action')
-    ->withName('library_h6_action')
-    ->withController(Library::class)
-    ->defaults('action', 'library')
-    ->add();
+        /* Libraries - legacy routes (match after h5/h6) */
+        $mapper->buildRoute('/libraries/:library/docs/:file')
+            ->withName('library_docs')
+            ->withController(Library::class)
+            ->withAction('docs')
+            ->add();
 
-/* Libraries - legacy routes (match after h5/h6) */
-$mapper->buildRoute($_root . '/libraries/:library/docs/:file')
-    ->withName('library_docs')
-    ->withController(Library::class)
-    ->withAction('docs')
-    ->add();
+        $mapper->buildRoute('/libraries/:library')
+            ->withName('library')
+            ->withController(Library::class)
+            ->withAction('library')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/:library')
-    ->withName('library')
-    ->withController(Library::class)
-    ->withAction('library')
-    ->add();
+        $mapper->buildRoute('/libraries/:library/:action')
+            ->withName('library_action')
+            ->withController(Library::class)
+            ->defaults('action', 'library')
+            ->add();
 
-$mapper->buildRoute($_root . '/libraries/:library/:action')
-    ->withName('library_action')
-    ->withController(Library::class)
-    ->defaults('action', 'library')
-    ->add();
+        /* Development */
+        $mapper->buildRoute('/development/:action')
+            ->withName('development')
+            ->withController(Development::class)
+            ->defaults('action', 'index')
+            ->add();
 
-/* Development */
-$mapper->buildRoute($_root . '/development/:action')
-    ->withName('development')
-    ->withController(Development::class)
-    ->defaults('action', 'index')
-    ->add();
+        /* Services */
+        $mapper->buildRoute('/services')
+            ->withName('services')
+            ->withController(Services::class)
+            ->withAction('index')
+            ->add();
 
-/* Services */
-$mapper->buildRoute($_root . '/services')
-    ->withName('services')
-    ->withController(Services::class)
-    ->withAction('index')
-    ->add();
+        /* Downloads - Horde 5 archive */
+        $mapper->buildRoute('/download/h5/:app')
+            ->withName('download_h5')
+            ->withController(Download::class)
+            ->withAction('h5')
+            ->add();
 
-/* Downloads - Horde 5 archive */
-$mapper->buildRoute($_root . '/download/h5/:app')
-    ->withName('download_h5')
-    ->withController(Download::class)
-    ->withAction('h5')
-    ->add();
+        /* Downloads - Horde 6 */
+        $mapper->buildRoute('/download/h6/:app')
+            ->withName('download_h6')
+            ->withController(Download::class)
+            ->withAction('h6')
+            ->add();
 
-/* Downloads - Horde 6 */
-$mapper->buildRoute($_root . '/download/h6/:app')
-    ->withName('download_h6')
-    ->withController(Download::class)
-    ->withAction('h6')
-    ->add();
+        /* Downloads - legacy route aliases to H6 */
+        $mapper->buildRoute('/download/:app')
+            ->withName('download')
+            ->withController(Download::class)
+            ->withAction('app')
+            ->add();
 
-/* Downloads - legacy route aliases to H6 */
-$mapper->buildRoute($_root . '/download/:app')
-    ->withName('download')
-    ->withController(Download::class)
-    ->withAction('app')
-    ->add();
+        /* Shop */
+        $mapper->buildRoute('/shop/us')
+            ->withName('shopus')
+            ->withController(Shop::class)
+            ->withAction('us')
+            ->add();
 
-/* Shop */
-$mapper->buildRoute($_root . '/shop/us')
-    ->withName('shopus')
-    ->withController(Shop::class)
-    ->withAction('us')
-    ->add();
+        $mapper->buildRoute('/shop/eu')
+            ->withName('shopeu')
+            ->withController(Shop::class)
+            ->withAction('eu')
+            ->add();
 
-$mapper->buildRoute($_root . '/shop/eu')
-    ->withName('shopeu')
-    ->withController(Shop::class)
-    ->withAction('eu')
-    ->add();
+        /* Diagnostics — feed/library cache round-trip probe. Gated by
+         * $diag_token in config/conf.php; if the token is unset the
+         * controller returns 404 so the route is indistinguishable from
+         * an unknown path. */
+        $mapper->buildRoute('/_diag/feed-cache')
+            ->withName('diag_feed_cache')
+            ->withController(Diagnostics::class)
+            ->withAction('index')
+            ->add();
+    },
+);

--- a/dispatch.php
+++ b/dispatch.php
@@ -3,6 +3,27 @@
  * Main dispatch page - PSR-7 version
  *
  * Copyright 2011-2026 Horde LLC (http://www.horde.org)
+ *
+ * hordeweb is dispatched two ways:
+ *
+ *   1. Standalone: this file is the entry point. The webroot prefix is
+ *      derived from config/conf.php's $host_base (path component), and
+ *      $fs_base points at hordeweb's filesystem root. There is no Horde
+ *      registry entry for hordeweb because the site is not embedded in
+ *      a larger Horde install.
+ *
+ *   2. Registered as a Horde app under horde/rampage.php. Horde\Core's
+ *      RuntimeRoutesProvider walks the registry, finds hordeweb's
+ *      registry.d snippet, and loads config/routes.php inside a group
+ *      whose prefix is the registered webroot and whose defaults set
+ *      ['app' => 'hordeweb']. This dispatcher is not invoked in that
+ *      mode; rampage matches, resolves the controller from the injector,
+ *      and runs the middleware stack itself.
+ *
+ * config/routes.php is app-relative: it must define routes without any
+ * webroot prefix. Both dispatchers wrap the include in a Horde\Routes
+ * GroupMapper group that supplies the correct prefix and app default,
+ * so the same routes file works verbatim under both entry points.
  */
 
 declare(strict_types=1);
@@ -13,8 +34,7 @@ use Horde\Http\StreamFactory;
 use Horde\Http\UriFactory;
 use Horde\Http\Server\RequestBuilder;
 use Horde\Http\Server\ResponseWriterWeb;
-use Horde\Routes\Matcher;
-use Horde\Routes\Mapper;
+use Horde\Routes\GroupMapper;
 use Horde\Routes\Utils;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -32,7 +52,9 @@ if (!class_exists('Composer\Autoload\ClassLoader', false)) {
     }
 }
 
-// Initialize Horde framework (loads config, sets up injector)
+// Initialize Horde framework (loads config, sets up injector).
+// After this returns, $host_base and $fs_base from config/conf.php
+// are available as globals.
 require_once dirname(__FILE__) . '/app/lib/base.php';
 
 // Create PSR-17 factories and register in injector for reuse
@@ -50,53 +72,79 @@ $injector->setInstance(ResponseFactoryInterface::class, $responseFactory);
 $requestBuilder = new RequestBuilder($requestFactory, $streamFactory, $uriFactory);
 $psr7Request = $requestBuilder->withGlobalVariables()->build();
 
-// Create modern Mapper and load routes
-$mapper = new Mapper();
-$injector->setInstance(Mapper::class, $mapper);
+// Derive the webroot prefix from config/conf.php's $host_base. In
+// standalone mode there is no registry entry to consult; $host_base
+// carries both the scheme+host and the path prefix ('/hordeweb', or
+// '' when hordeweb is mounted at the document root).
+$webrootPrefix = rtrim((string) parse_url($host_base ?? '', PHP_URL_PATH), '/');
 
-// Load routes into mapper
-$registry = $injector->getInstance('Horde_Registry');
-require dirname(__FILE__) . '/config/routes.php';
+// Create modern GroupMapper and load routes under a group whose prefix
+// matches the deployed webroot and whose defaults set the app. This
+// mirrors what horde/Core's RuntimeRoutesProvider does for registered
+// apps, so config/routes.php can stay app-relative.
+$mapper = new GroupMapper();
+$injector->setInstance(GroupMapper::class, $mapper);
+
+$mapper->group(
+    [
+        'prefix' => $webrootPrefix,
+        'defaults' => ['app' => 'hordeweb'],
+    ],
+    function (GroupMapper $mapper) {
+        require dirname(__FILE__) . '/config/routes.php';
+    },
+);
+$mapper->compile();
 
 // Create Utils for URL generation (replaces legacy Horde_Controller_UrlWriter)
 $utils = new Utils($mapper);
 $injector->setInstance(Utils::class, $utils);
 
-// Match route using PSR-7-aware Matcher
-$matcher = new Matcher($mapper, $psr7Request);
-$match = $matcher->getMatchDict();
+// Match the incoming path directly against the GroupMapper. Matcher
+// (the PSR-7-aware wrapper) is Mapper-typed and would not accept a
+// GroupMapper; routematch() is the canonical entry point on both and
+// is what rampage uses as well.
+$path = $psr7Request->getUri()->getPath();
+$result = $mapper->routematch($path);
 
-// Determine controller from route
+if ($result === null) {
+    $psr7Response = $responseFactory->createResponse(404, 'Not Found')
+        ->withBody($streamFactory->createStream(
+            '<h1>404 Not Found</h1><p>No route matched: '
+            . htmlspecialchars($path, ENT_QUOTES, 'UTF-8')
+            . '</p>',
+        ));
+    (new ResponseWriterWeb())->writeResponse($psr7Response);
+    return;
+}
+
+[$match, $route] = $result;
+
+// Determine controller from route. hordeweb's routes define FQCN
+// controllers via ->withController(Home::class); the legacy short-name
+// fallback is kept so any pre-modern route still resolves.
 $controllerClass = $match['controller'] ?? 'home';
-
-// If controller is a string (not FQCN), it's from legacy routes - convert to FQCN
 if (!class_exists($controllerClass)) {
     $controllerClass = 'Horde\\Hordeweb\\Controller\\' . ucfirst($controllerClass);
 }
 
-// Instantiate PSR-15 controller
 if (!class_exists($controllerClass)) {
-    // Controller not found - 404
-    $psr7Response = $responseFactory->createResponse(404, 'Not Found');
-    $body = $streamFactory->createStream('<h1>404 Not Found</h1><p>Controller not found.</p>');
-    $psr7Response = $psr7Response->withBody($body);
+    $psr7Response = $responseFactory->createResponse(404, 'Not Found')
+        ->withBody($streamFactory->createStream(
+            '<h1>404 Not Found</h1><p>Controller not found.</p>',
+        ));
 } else {
     $controller = new $controllerClass($injector, $responseFactory, $streamFactory);
 
-    // Verify it implements RequestHandlerInterface
     if (!$controller instanceof RequestHandlerInterface) {
         throw new \RuntimeException(
-            "Controller {$controllerClass} must implement RequestHandlerInterface"
+            "Controller {$controllerClass} must implement RequestHandlerInterface",
         );
     }
 
-    // Store route match in request attribute
-    $psr7Request = $psr7Request->withAttribute('route', iterator_to_array($match));
-
-    // Execute controller (returns PSR-7 response directly)
+    $psr7Request = $psr7Request->withAttribute('route', $match);
     $psr7Response = $controller->handle($psr7Request);
 }
 
 // Output response
-$responseWriter = new ResponseWriterWeb();
-$responseWriter->writeResponse($psr7Response);
+(new ResponseWriterWeb())->writeResponse($psr7Response);

--- a/src/Controller/App.php
+++ b/src/Controller/App.php
@@ -20,24 +20,45 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde_Feed;
+use Horde_Http_Client;
 use Horde_Service_Gravatar;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
+use Psr\SimpleCache\CacheInterface;
+use Throwable;
 
 /**
  * App controller - PSR-15 RequestHandler
  */
 class App implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    /**
+     * Per-app news-feed cache key prefix. See {@see Home} for the
+     * rationale on the 'hordeweb.' / '.v2' namespace choice — this
+     * class shares the same keyspace so cron warmup and diagnostics
+     * see a single, coherent picture.
+     */
+    private const CACHE_KEY_APP_FEED_PREFIX = 'hordeweb.feed.app.';
+    private const CACHE_KEY_APP_FEED_SUFFIX = '.v2';
+
+    /** TTL (seconds) for a successfully fetched per-app feed. */
+    private const SUCCESS_TTL = 600;
+
+    /**
+     * TTL (seconds) for the negative-result sentinel. See
+     * {@see Home::NEGATIVE_TTL}.
+     */
+    private const NEGATIVE_TTL = 60;
+
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
     private array $route;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {
@@ -120,27 +141,49 @@ class App implements RequestHandlerInterface
             return $this->notFoundAction();
         }
 
-        // Build the bug/news widget
+        // Build the bug/news widget. Per-app tagged view of the same
+        // horde-wide feed the Home controller shows.
         $cache = HordeWeb_Utils::getCache();
+        $feedTimeout = $GLOBALS['feed_timeout'] ?? 5;
+        $httpClient = new Horde_Http_Client(['request.timeout' => $feedTimeout]);
         $slugs = array($app);
         $view->latestNews = array();
         foreach ($slugs as $slug) {
-            $base_feed_url = \Horde::url($GLOBALS['feed_url'])->add('tag_id', $slug)->setRaw(true);
-            if ($latestnews = $cache->get('hordefeed' . $slug, 600)) {
-                $view->latestNews = unserialize($latestnews);
-            } else {
-                try {
-                    $i = 1;
-                    foreach (Horde_Feed::readUri($base_feed_url) as $entry) {
-                        $view->latestNews[] = $entry;
-                        if (++$i > 5) {
-                            break;
-                        }
-                    }
-                } catch (\Exception $e) {
+            $key = self::CACHE_KEY_APP_FEED_PREFIX . $slug . self::CACHE_KEY_APP_FEED_SUFFIX;
+
+            $cached = $cache->get($key);
+            if ($cached !== null) {
+                $unserialized = @unserialize($cached);
+                if (is_array($unserialized)) {
+                    $view->latestNews = $unserialized;
+                    continue;
                 }
-                $cache->set('hordefeed' . $slug, serialize($view->latestNews));
             }
+
+            // Recent failure: don't retry-storm.
+            if ($cache->get($key . '.failed') !== null) {
+                continue;
+            }
+
+            $base_feed_url = \Horde::url($GLOBALS['feed_url'])->add('tag_id', $slug)->setRaw(true);
+            $items = array();
+            try {
+                $i = 1;
+                foreach (Horde_Feed::readUri($base_feed_url, $httpClient) as $entry) {
+                    $items[] = $entry;
+                    if (++$i > 5) {
+                        break;
+                    }
+                }
+            } catch (Throwable $e) {
+                // Stamp negative sentinel; leave any previously-cached
+                // good copy intact (we only get here on a *fresh* miss).
+                $cache->set($key . '.failed', 1, self::NEGATIVE_TTL);
+                continue;
+            }
+
+            $view->latestNews = $items;
+            $cache->set($key, serialize($items), self::SUCCESS_TTL);
         }
 
         return $this->renderTemplate($view, 'app', 'main');

--- a/src/Controller/Community.php
+++ b/src/Controller/Community.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde_Service_Gravatar;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
@@ -30,12 +30,12 @@ use HordeWeb_Utils;
  */
 class Community implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Development.php
+++ b/src/Controller/Development.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
 
@@ -29,12 +29,12 @@ use HordeWeb_Utils;
  */
 class Development implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Diagnostics.php
+++ b/src/Controller/Diagnostics.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * PSR-15 diagnostics controller for hordeweb.
+ *
+ * Read-only probes into the feed / library cache so operators can verify
+ * that:
+ *
+ *   1. The controllers and bin/hordeweb-fetch-feed resolve the same
+ *      PSR-16 CacheInterface (i.e. cron warmups actually end up in the
+ *      same backend the request path reads from).
+ *   2. The known cache keys are populated, and the payloads unserialize
+ *      to the expected types.
+ *   3. A write from this request is readable within the same request
+ *      (canary round-trip).
+ *
+ * Gated by a shared token in $GLOBALS['diag_token'] (set in hordeweb's
+ * config/conf.php alongside $feed_url and $feed_timeout).
+ * Unset or empty → the endpoint returns a plain 404 as if it did not
+ * exist. This is deliberately not admin auth — the endpoint leaks
+ * class names and payload sizes, not secrets, but it should still not
+ * be discoverable to crawlers.
+ *
+ * Copyright 2026 Horde LLC (http://www.horde.org)
+ *
+ * @license  http://opensource.org/licenses/bsd-license.php BSD
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Hordeweb\Controller;
+
+use Horde\Injector\Injector;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\SimpleCache\CacheInterface;
+use Throwable;
+
+class Diagnostics implements RequestHandlerInterface
+{
+    /**
+     * Probes: cache keys we expect to find populated, mapped to a short
+     * description used only for the JSON output. The keys must match
+     * Home::CACHE_KEY_* / App::CACHE_KEY_APP_FEED_* / the
+     * HordeWeb_Utils_Libraries prefixes.
+     */
+    private const PROBES = [
+        'hordeweb.feed.planet.v2'          => 'Planet Horde feed (Home)',
+        'hordeweb.feed.horde.v2'           => 'Horde news feed (Home)',
+        'hordeweb.feed.app.imp.v2'         => 'Per-app feed sample (App, slug=imp)',
+        'hordeweb.libraries.list.h6'       => 'Library list (h6)',
+        'hordeweb.libraries.descriptions.h6' => 'Library descriptions (h6)',
+    ];
+
+    /** Canary key used to prove read-your-own-write inside this request. */
+    private const CANARY_KEY = 'hordeweb.diag.canary';
+
+    public function __construct(
+        private readonly Injector $injector,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $expectedToken = $GLOBALS['diag_token'] ?? null;
+        if ($expectedToken === null || $expectedToken === '') {
+            return $this->notFound();
+        }
+        $providedToken = $request->getQueryParams()['token'] ?? '';
+        if (!is_string($providedToken) || !hash_equals((string) $expectedToken, $providedToken)) {
+            return $this->notFound();
+        }
+
+        $cache = $this->injector->getInstance(CacheInterface::class);
+
+        $out = [
+            'ok' => true,
+            'backend' => $this->describeBackend($cache),
+            'probes' => [],
+            'canary' => $this->canaryRoundTrip($cache),
+        ];
+
+        foreach (self::PROBES as $key => $description) {
+            $out['probes'][$key] = $this->probe($cache, $key, $description);
+        }
+
+        return $this->json($out);
+    }
+
+    /**
+     * Return the concrete class of the injected PSR-16 cache plus, where
+     * available via reflection, the concrete storage layer inside it.
+     * Everything else (Redis host, prefix) is not leaked — the goal is
+     * only to prove "web and CLI resolve the same class."
+     */
+    private function describeBackend(CacheInterface $cache): array
+    {
+        $info = [
+            'cache_class' => get_class($cache),
+            'storage_class' => null,
+        ];
+
+        try {
+            $ref = new \ReflectionObject($cache);
+            foreach ($ref->getProperties(\ReflectionProperty::IS_PRIVATE | \ReflectionProperty::IS_PROTECTED) as $prop) {
+                $name = strtolower($prop->getName());
+                if (!str_contains($name, 'storage')) {
+                    continue;
+                }
+                $prop->setAccessible(true);
+                $value = $prop->getValue($cache);
+                if (is_object($value)) {
+                    $info['storage_class'] = get_class($value);
+                    break;
+                }
+            }
+        } catch (Throwable) {
+            // Reflection is a best-effort diagnostic; a failure here
+            // does not compromise the endpoint's core purpose.
+        }
+
+        return $info;
+    }
+
+    /**
+     * Read one cache key. Report hit/miss, payload size, and — if the
+     * payload is a serialize()d string — the class of the top-level
+     * unserialized value. No payload contents are ever emitted.
+     */
+    private function probe(CacheInterface $cache, string $key, string $description): array
+    {
+        try {
+            $value = $cache->get($key);
+        } catch (Throwable $e) {
+            return [
+                'description' => $description,
+                'error' => get_class($e) . ': ' . $e->getMessage(),
+            ];
+        }
+
+        if ($value === null) {
+            return [
+                'description' => $description,
+                'hit' => false,
+            ];
+        }
+
+        $out = [
+            'description' => $description,
+            'hit' => true,
+            'raw_type' => gettype($value),
+            'raw_size_bytes' => is_string($value) ? strlen($value) : null,
+        ];
+
+        if (is_string($value)) {
+            $unserialized = @unserialize($value);
+            if ($unserialized === false && $value !== 'b:0;') {
+                $out['payload'] = ['unserialize' => 'failed'];
+            } else {
+                $out['payload'] = [
+                    'type' => gettype($unserialized),
+                    'class' => is_object($unserialized) ? get_class($unserialized) : null,
+                    'iterable' => is_iterable($unserialized),
+                    'count' => is_countable($unserialized) ? count($unserialized) : null,
+                ];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Prove read-your-own-write. Uses hrtime() as the payload so
+     * successive canaries never collide even on the same second.
+     */
+    private function canaryRoundTrip(CacheInterface $cache): array
+    {
+        $stamp = (string) hrtime(true);
+        try {
+            $cache->set(self::CANARY_KEY, $stamp, 60);
+            $readback = $cache->get(self::CANARY_KEY);
+        } catch (Throwable $e) {
+            return [
+                'ok' => false,
+                'error' => get_class($e) . ': ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'ok' => $readback === $stamp,
+            'wrote' => $stamp,
+            'read' => $readback,
+        ];
+    }
+
+    private function json(array $data): ResponseInterface
+    {
+        $body = $this->streamFactory->createStream(
+            json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+        );
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'no-store')
+            ->withBody($body);
+    }
+
+    private function notFound(): ResponseInterface
+    {
+        $body = $this->streamFactory->createStream("Not Found\n");
+        return $this->responseFactory->createResponse(404)
+            ->withHeader('Content-Type', 'text/plain')
+            ->withBody($body);
+    }
+}

--- a/src/Controller/Download.php
+++ b/src/Controller/Download.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
 
@@ -29,14 +29,14 @@ use HordeWeb_Utils;
  */
 class Download implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
     private array $route;
     private string $era = 'h6';
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Home.php
+++ b/src/Controller/Home.php
@@ -21,8 +21,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
-use Horde_Injector;
-use Horde_Cache;
+use Horde\Injector\Injector;
 use Horde_Feed;
 use Horde_Http_Client;
 use HordeWeb_Utils;
@@ -33,6 +32,7 @@ use Horde\Routes\Utils;
 use Horde\Log\Logger;
 use Horde\Log\Handler\Syslog as SyslogHandler;
 use Horde\Log\LogLevels;
+use Psr\SimpleCache\CacheInterface;
 use Throwable;
 
 /**
@@ -43,13 +43,37 @@ use Throwable;
  */
 class Home implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    /**
+     * Feed cache keys. Namespaced with 'hordeweb.' because the injected
+     * PSR-16 cache is a *site-shared* keyspace (Redis on typical Horde
+     * installs); the app has to prefix its own keys. The 'v2' suffix
+     * lets us invalidate wholesale when the on-wire serialized layout
+     * of Horde_Feed_* changes.
+     *
+     * The cron script bin/hordeweb-fetch-feed writes to the same keys
+     * at the same TTL; the diagnostics controller reads them.
+     */
+    private const CACHE_KEY_PLANET    = 'hordeweb.feed.planet.v2';
+    private const CACHE_KEY_HORDEFEED = 'hordeweb.feed.horde.v2';
+
+    /** TTL (seconds) for a successfully fetched feed. */
+    private const SUCCESS_TTL = 600;
+
+    /**
+     * TTL (seconds) for the negative-result sentinel keyed at
+     * '<feedKey>.failed'. Short enough that a temporarily-broken remote
+     * comes back quickly once it recovers; long enough that a persistent
+     * outage doesn't retry-storm on every request.
+     */
+    private const NEGATIVE_TTL = 60;
+
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
     private LoggerInterface $logger;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {
@@ -118,74 +142,93 @@ class Home implements RequestHandlerInterface
             array($GLOBALS['fs_base'] . '/app/views/Home')
         );
 
-        $cache = $this->injector->getInstance(Horde_Cache::class);
+        $cache = $this->injector->getInstance(CacheInterface::class);
 
-        // Cache version to invalidate old serialized data
-        $cacheVersion = 'v2';
-
-        // Create HTTP client with custom timeout
+        // Create HTTP client with custom timeout. Used for the fallback
+        // fetch when the cache is cold; the cron-run bin/hordeweb-fetch-feed
+        // is meant to keep it warm.
         $feedTimeout = $GLOBALS['feed_timeout'] ?? 5;
         $httpClient = new Horde_Http_Client(['request.timeout' => $feedTimeout]);
 
-        // Get the planet feed
-        $planetKey = 'planet_' . $cacheVersion;
-        $view->planet = null;
-        if ($planet = $cache->get($planetKey, 600)) {
-            $unserialized = @unserialize($planet);
-            // Validate it's a traversable feed object
-            if ($unserialized && is_iterable($unserialized)) {
-                $view->planet = $unserialized;
-            }
-        }
+        // Planet Horde: the "Ralf writes about Horde" tag feed.
+        $view->planet = $this->_loadFeed(
+            $cache,
+            self::CACHE_KEY_PLANET,
+            $GLOBALS['planet_feed_url'] ?? 'https://www.ralf-lang.de/tag/horde/feed/',
+            $httpClient,
+            'planet',
+        );
 
-        if ($view->planet === null) {
-            try {
-                // Use config variable with fallback to default
-                $planetFeedUrl = $GLOBALS['planet_feed_url'] ?? 'https://www.ralf-lang.de/tag/horde/feed/';
-                // Suppress deprecation warnings from Horde_Xml_Element
-                $view->planet = @Horde_Feed::readUri($planetFeedUrl, $httpClient);
-            } catch (Throwable $e) {
-                $this->logger->error(
-                    'Home controller: Failed to fetch Planet Horde feed: {exception}: {message}',
-                    [
-                        'exception' => get_class($e),
-                        'message' => $e->getMessage(),
-                    ]
-                );
-                $view->planet = null;
-            }
-            $cache->set($planetKey, serialize($view->planet));
-        }
-
-        // Get the complete Horde feed (no tags)
-        $hordefeedKey = 'hordefeed_' . $cacheVersion;
-        $view->hordefeed = null;
-        if ($hordefeed = $cache->get($hordefeedKey, 600)) {
-            $unserialized = @unserialize($hordefeed);
-            // Validate it's a traversable feed object
-            if ($unserialized && is_iterable($unserialized)) {
-                $view->hordefeed = $unserialized;
-            }
-        }
-
-        if ($view->hordefeed === null) {
-            try {
-                // Suppress deprecation warnings from Horde_Xml_Element
-                $view->hordefeed = @Horde_Feed::readUri($GLOBALS['feed_url'], $httpClient);
-            } catch (Throwable $e) {
-                $this->logger->error(
-                    'Home controller: Failed to fetch Horde news feed: {exception}: {message}',
-                    [
-                        'exception' => get_class($e),
-                        'message' => $e->getMessage(),
-                    ]
-                );
-                $view->hordefeed = null;
-            }
-            $cache->set($hordefeedKey, serialize($view->hordefeed));
-        }
+        // The main horde.org news feed (no tag filter).
+        $view->hordefeed = $this->_loadFeed(
+            $cache,
+            self::CACHE_KEY_HORDEFEED,
+            $GLOBALS['feed_url'],
+            $httpClient,
+            'horde news',
+        );
 
         return $this->renderTemplate($view, 'index', 'home');
+    }
+
+    /**
+     * Read one feed from the PSR-16 cache, falling back to a synchronous
+     * HTTP fetch on cold cache.
+     *
+     * Two behaviours worth calling out:
+     *  - **Negative-result guarding.** When {@see Horde_Feed::readUri()}
+     *    throws we stamp a short-lived sentinel under a paired '.failed'
+     *    key. While that sentinel is present we skip the fetch entirely
+     *    and return null — so a broken remote feed costs one 5 s timeout
+     *    per {@see self::NEGATIVE_TTL} window instead of one per request.
+     *  - **Successful hits carry a full TTL.** {@see self::SUCCESS_TTL}
+     *    (10 minutes) at PSR-16 set() time; the cron script
+     *    (bin/hordeweb-fetch-feed) writes to the same key at the same
+     *    TTL so cron-warmed entries are indistinguishable from
+     *    request-warmed ones.
+     */
+    private function _loadFeed(
+        CacheInterface $cache,
+        string $key,
+        string $url,
+        Horde_Http_Client $httpClient,
+        string $label,
+    ) {
+        $cached = $cache->get($key);
+        if ($cached !== null) {
+            $unserialized = @unserialize($cached);
+            if ($unserialized && is_iterable($unserialized)) {
+                return $unserialized;
+            }
+        }
+
+        // Recent failure: don't retry-storm the broken endpoint.
+        if ($cache->get($key . '.failed') !== null) {
+            return null;
+        }
+
+        try {
+            // Suppress deprecation warnings from Horde_Xml_Element
+            $feed = @Horde_Feed::readUri($url, $httpClient);
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Home controller: Failed to fetch ' . $label . ' feed: {exception}: {message}',
+                [
+                    'exception' => get_class($e),
+                    'message' => $e->getMessage(),
+                ]
+            );
+            $cache->set($key . '.failed', 1, self::NEGATIVE_TTL);
+            return null;
+        }
+
+        if ($feed === null || $feed === false) {
+            $cache->set($key . '.failed', 1, self::NEGATIVE_TTL);
+            return null;
+        }
+
+        $cache->set($key, serialize($feed), self::SUCCESS_TTL);
+        return $feed;
     }
 
     /**

--- a/src/Controller/Library.php
+++ b/src/Controller/Library.php
@@ -21,7 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
 
@@ -30,14 +30,14 @@ use HordeWeb_Utils;
  */
 class Library implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
     private array $route;
     private string $era = 'h6';
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Licenses.php
+++ b/src/Controller/Licenses.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
 
@@ -29,12 +29,12 @@ use HordeWeb_Utils;
  */
 class Licenses implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Screenshot.php
+++ b/src/Controller/Screenshot.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
 
@@ -29,12 +29,12 @@ use HordeWeb_Utils;
  */
 class Screenshot implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Services.php
+++ b/src/Controller/Services.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 
 /**
@@ -28,12 +28,12 @@ use Horde\Routes\Utils;
  */
 class Services implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Shop.php
+++ b/src/Controller/Shop.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 
 /**
@@ -28,12 +28,12 @@ use Horde\Routes\Utils;
  */
 class Shop implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Controller/Support.php
+++ b/src/Controller/Support.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Horde_Injector;
+use Horde\Injector\Injector;
 use Horde\Routes\Utils;
 use HordeWeb_Utils;
 
@@ -29,12 +29,12 @@ use HordeWeb_Utils;
  */
 class Support implements RequestHandlerInterface
 {
-    private Horde_Injector $injector;
+    private Injector $injector;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 
     public function __construct(
-        Horde_Injector $injector,
+        Injector $injector,
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ) {

--- a/src/Middleware/LegacyBootstrap.php
+++ b/src/Middleware/LegacyBootstrap.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Legacy bootstrap middleware for hordeweb
+ *
+ * Copyright 2026 Horde LLC (http://www.horde.org)
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Hordeweb\Middleware;
+
+use Horde\Core\Uri\RoutesProvider;
+use Horde\Routes\GroupMapper;
+use Horde\Routes\Utils;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Require hordeweb's legacy app/lib/base.php before dispatching the
+ * controller.
+ *
+ * Under hordeweb's own dispatch.php, base.php is included at boot and
+ * installs:
+ *
+ *   - Horde_Registry::appInit (session, config, legacy autoloader)
+ *   - PSR-0 class-path mappers for HordeWeb_* and legacy per-app
+ *     directories (settings/, controllers/, lib/)
+ *   - The bindFactory('HordeWeb_View', ...) call needed by the views
+ *
+ * Under horde/rampage.php none of that runs, so controllers that
+ * reference legacy classes (Horde_PageOutput, HordeWeb_View,
+ * HordeWeb_Script_File, ...) fail at construction time.
+ *
+ * This middleware runs before any hordeweb controller and require_once
+ * the file, so the second and later invocations are cheap.
+ *
+ * It also binds a properly-populated Horde\Routes\Utils into the legacy
+ * injector. Under rampage the routes live inside the RoutesProvider
+ * (a GroupMapper) attached to the request; without the bind below, the
+ * legacy injector would reflection-instantiate a fresh empty Mapper and
+ * hand it to Utils, so every $view->urlWriter->urlFor(name, params)
+ * call in a template would fall through to the bare-name query-string
+ * fallback (yielding href="library?library=Horde_Date" and similar).
+ *
+ * Once every legacy dependency has been ported to PSR-4/DI and templates
+ * switch to Horde\Core\Uri\RouteUrlWriter, this middleware can be
+ * removed together with app/lib/base.php.
+ */
+class LegacyBootstrap implements MiddlewareInterface
+{
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        require_once dirname(__DIR__, 2) . '/app/lib/base.php';
+
+        // Bridge the populated GroupMapper into the legacy injector via a
+        // Utils bound to it. The RoutesProvider that rampage stashed in
+        // the legacy injector is the same GroupMapper that resolved this
+        // request, so its named-route table is what templates need to see.
+        $injector = $GLOBALS['injector'] ?? null;
+        if ($injector !== null && $injector->has(RoutesProvider::class)) {
+            $provider = $injector->getInstance(RoutesProvider::class);
+            if ($provider instanceof GroupMapper) {
+                $injector->setInstance(Utils::class, new Utils($provider));
+            }
+        }
+
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
The hordeweb controllers, HordeWeb_Utils_Libraries, and bin/hordeweb-fetch-feed all cached via legacy Horde_Cache under separate keys with no shared TTL semantics. Move the whole set to Psr\SimpleCache\CacheInterface resolved via Horde\Core\Factory\SimpleCacheFactory so cron warmup and the request path share one backend (HashTable/Redis on prod) and one keyspace.

Feed keys are now hordeweb.feed.planet.v2, hordeweb.feed.horde.v2 and hordeweb.feed.app.<slug>.v2; library keys are hordeweb.libraries.list.<era> and hordeweb.libraries.descriptions.<era>. Failed fetches stamp a short-lived .failed sentinel so a broken remote costs one timeout per NEGATIVE_TTL window instead of one per request. bin/hordeweb-fetch-feed loses the pre-fetch cache-clear that was destroying warm entries; it now writes only on success and leaves the previous good copy in place on failure.

Adds a Diagnostics controller at /_diag/feed-cache (gated by $diag_token) that reports the resolved PSR-16 backend class, the hit/miss/payload-class of each known cache key, and a canary write/read to prove request-time read-your-own-write against the same backend.
